### PR TITLE
Add x86_64 architecture for iOS build

### DIFF
--- a/Challenge 1/src/XamarinAlliance/iOS/XamarinAllianceApp.iOS.csproj
+++ b/Challenge 1/src/XamarinAlliance/iOS/XamarinAllianceApp.iOS.csproj
@@ -19,7 +19,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>True</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
@@ -43,7 +43,7 @@
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <MtouchLink>None</MtouchLink>
   </PropertyGroup>


### PR DESCRIPTION
Supporting 64-bit architecture on iOS Simulator. Without this support, iOS alerts that the app may slow down your iPhone.